### PR TITLE
Adds flexibility with command line arguments

### DIFF
--- a/examples/get-reader-info.py
+++ b/examples/get-reader-info.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import sys
 
 from chafon_rfid.base import CommandRunner, ReaderCommand, ReaderInfoFrame

--- a/examples/get-reader-info.py
+++ b/examples/get-reader-info.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import sys
 
 from chafon_rfid.base import CommandRunner, ReaderCommand, ReaderInfoFrame
@@ -7,27 +5,19 @@ from chafon_rfid.command import CF_GET_READER_INFO
 from chafon_rfid.transport import TcpTransport
 from chafon_rfid.transport_serial import SerialTransport
 
-TCP_PORT = 6000
-
-
 def get_reader_info(runner):
     get_reader_info = ReaderCommand(CF_GET_READER_INFO)
     reader_info = ReaderInfoFrame(runner.run(get_reader_info))
     return reader_info
 
-
-def print_reader_info(reader_addr):
-
-    # transport = TcpTransport(reader_addr=reader_addr, reader_port=TCP_PORT)
-    # transport = SerialTransport(device='/dev/ttyS0')
-    # transport = SerialTransport(device='/dev/ttyAMA0')
-    # transport = SerialTransport(device='/dev/ttyUSB0')
+def print_reader_info(reader_addr, baud_rate=None, tcp_port=None):
     if reader_addr.startswith('/') or reader_addr.startswith('COM'):
-        transport = SerialTransport(device=reader_addr)
+        transport = SerialTransport(device=reader_addr, baud_rate=baud_rate)
     else:
-        transport = TcpTransport(reader_addr, reader_port=TCP_PORT)
+        transport = TcpTransport(reader_addr, reader_port=tcp_port, auto_connect=True)
 
     runner = CommandRunner(transport)
+
     try:
         reader_info = get_reader_info(runner)
         print('Reader info: type %s version %d.%d' % (reader_info.type.name, reader_info.firmware_version[0], reader_info.firmware_version[1]))
@@ -39,10 +29,19 @@ def print_reader_info(reader_addr):
 
     transport.close()
 
+def print_usage_instruction():
+    print('Usage: {0} <connection_type> <reader-address> <baud-rate> OR <tcp-port>'.format(sys.argv[0]))
+
 
 if __name__ == "__main__":
 
     if len(sys.argv) >= 2:
-        print_reader_info(sys.argv[1])
+        if sys.argv[1] == 'com':
+            print_reader_info(sys.argv[2], baud_rate=sys.argv[3])
+        elif sys.argv[1] == 'tcp':
+            print_reader_info(sys.argv[2], tcp_port=int(sys.argv[3]))
+        else:
+            print_usage_instruction()
     else:
-        print('Usage: {0} <reader-address>'.format(sys.argv[0]))
+        print_usage_instruction()
+


### PR DESCRIPTION
I was stung by the default baud rate being different on the reader I'm using compared to the default in the package. While I was adding a command line argument for that I thought I'd better do the same for the TCP connection too.